### PR TITLE
Add client-side authentication

### DIFF
--- a/packages/api/src/main.rs
+++ b/packages/api/src/main.rs
@@ -57,7 +57,10 @@ async fn main() {
         .route("/", get(index))
         .nest(
             "/auth",
-            Router::new().route("/register", post(routes::auth::register)),
+            Router::new()
+                .route("/register", post(routes::auth::register))
+                .route("/login", post(routes::auth::login))
+                .route("/logout", get(routes::auth::logout)),
         )
         .nest(
             "/user",

--- a/packages/api/src/main.rs
+++ b/packages/api/src/main.rs
@@ -59,8 +59,7 @@ async fn main() {
             "/auth",
             Router::new()
                 .route("/register", post(routes::auth::register))
-                .route("/login", post(routes::auth::login))
-                .route("/logout", get(routes::auth::logout)),
+                .route("/login", post(routes::auth::login)),
         )
         .nest(
             "/user",

--- a/packages/api/src/routes/auth.rs
+++ b/packages/api/src/routes/auth.rs
@@ -123,7 +123,7 @@ pub async fn login(
     // Finally, check the passwords
     if let Some(user) = user {
         user.check_password(payload.password)
-            .map_err(|_| StatusCode::BAD_REQUEST)?;and return it
+            .map_err(|_| StatusCode::BAD_REQUEST)?;
         let token =
             encode_jwt(&user.id.to_string()).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
         Ok(get_auth_response(&token))

--- a/packages/api/src/routes/auth.rs
+++ b/packages/api/src/routes/auth.rs
@@ -1,7 +1,13 @@
 use std::sync::Arc;
 
-use axum::{extract::State, http::StatusCode, Json};
-use db::users::{hash_password, insert_user};
+use axum::{
+    body::Body,
+    extract::State,
+    http::{header, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+use db::users::User;
 use serde::{Deserialize, Serialize};
 
 use crate::{jwt::encode_jwt, AppState};
@@ -14,9 +20,11 @@ pub struct RegisterRequest {
     password_confirmation: String,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
-pub struct RegisterResponse {
-    token: String,
+#[derive(Deserialize)]
+pub struct LoginRequest {
+    username: Option<String>,
+    email: Option<String>,
+    password: String,
 }
 
 #[derive(Serialize)]
@@ -24,60 +32,114 @@ pub struct ErrorResponse {
     message: String,
 }
 
-// Handle user registration with password hashing and validation
+/// A function for setting a JWT to a response cookie
+fn get_auth_response(jwt_token: &str) -> impl IntoResponse {
+    let mut response = Response::builder()
+        .status(StatusCode::OK)
+        .body(Body::empty())
+        .unwrap();
+    let cookie = format!(
+        "jwt={}; HttpOnly; Path=/; Max-Age=86400; SameSite=Strict{}",
+        jwt_token,
+        if cfg!(debug_assertions) {
+            ""
+        } else {
+            "; Secure"
+        }
+    );
+    let cookie_header = HeaderValue::from_str(&cookie).expect("Could not parse cookie header");
+
+    response
+        .headers_mut()
+        .insert(header::SET_COOKIE, cookie_header);
+
+    response
+}
+
+/// Handle user registration with password hashing and validation
+/// Returns a cookie with a JWT set on successful response
 pub async fn register(
     State(state): State<Arc<AppState>>,
     Json(payload): Json<RegisterRequest>,
-) -> Result<Json<RegisterResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> impl IntoResponse {
     // Validate inputs
     if payload.password != payload.password_confirmation {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            Json(ErrorResponse {
-                message: "Passwords do not match".to_string(),
-            }),
-        ));
+        return Err(StatusCode::BAD_REQUEST);
     }
 
     if payload.username.is_empty() || payload.email.is_empty() || payload.password.is_empty() {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            Json(ErrorResponse {
-                message: "All fields are required".to_string(),
-            }),
-        ));
+        return Err(StatusCode::BAD_REQUEST);
     }
 
-    // Hash the password
-    let password_hash = hash_password(&payload.password).expect("Could not hash password");
-
+    // Create a new user
+    let mut user = User::new(payload.email, payload.username, payload.password);
+    // Make sure to hash the password
+    user.hash_password()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     // Insert the new user into the database
-    match insert_user(&state.db, &payload.email, &payload.username, &password_hash).await {
-        Ok(user_id) => {
-            let token = encode_jwt(&user_id).map_err(|_| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ErrorResponse {
-                        message: "Could not encode JWT token".to_string(),
-                    }),
-                )
-            })?;
-            Ok(Json(RegisterResponse { token }))
+    match user.insert(&state.db).await {
+        Ok(user) => {
+            let token =
+                encode_jwt(&user.id.to_string()).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+            let response = get_auth_response(&token);
+            Ok(response)
         }
-        Err(e) => {
-            let error_message = match e {
-                sqlx::Error::Database(ref db_error) if db_error.is_unique_violation() => {
-                    "Username or email already exists".to_string()
-                }
-                _ => "Failed to create user".to_string(),
-            };
-
-            Err((
-                StatusCode::BAD_REQUEST,
-                Json(ErrorResponse {
-                    message: error_message,
-                }),
-            ))
-        }
+        Err(_e) => Err(StatusCode::BAD_REQUEST),
     }
+}
+
+/// Handle user authentication
+/// Returns a cookie with a JWT set on successful response
+pub async fn login(
+    State(state): State<Arc<AppState>>,
+    Json(payload): Json<LoginRequest>,
+) -> impl IntoResponse {
+    // Make sure we have either a username or email to work with
+    if payload.email.is_none() && payload.username.is_none() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    // Grab the user based on either the username or email
+    let mut user: Option<User> = None;
+    // If the username is provided, it supercedes the email
+    if let Some(username) = payload.username {
+        user = Some(
+            User::from_username(username, &state.db)
+                .await
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
+        );
+    }
+    // Otherwise, we use the email
+    if let Some(email) = payload.email {
+        user = Some(
+            User::from_email(email, &state.db)
+                .await
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
+        )
+    }
+    // Finally, check the passwords
+    if let Some(user) = user {
+        user.check_password(payload.password)
+            .map_err(|_| StatusCode::BAD_REQUEST)?;
+        let token =
+            encode_jwt(&user.id.to_string()).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        Ok(get_auth_response(&token))
+    } else {
+        Err(StatusCode::INTERNAL_SERVER_ERROR)
+    }
+}
+
+/// Logout a user, clears the JWT cookie
+pub async fn logout() -> Response {
+    let mut response = Response::builder()
+        .status(StatusCode::OK)
+        .body(Body::empty())
+        .unwrap();
+
+    let cookie = "jwt=; HttpOnly; Path=/; Max-Age=0; SameSite=Strict";
+    let cookie_header = HeaderValue::from_str(cookie).unwrap();
+    response
+        .headers_mut()
+        .insert(header::SET_COOKIE, cookie_header);
+
+    response
 }

--- a/packages/api/src/routes/auth.rs
+++ b/packages/api/src/routes/auth.rs
@@ -98,6 +98,10 @@ pub async fn login(
     if payload.email.is_none() && payload.username.is_none() {
         return Err(StatusCode::BAD_REQUEST);
     }
+    // Make sure the password isn't empty
+    if payload.password.is_empty() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
     // Grab the user based on either the username or email
     let mut user: Option<User> = None;
     // If the username is provided, it supercedes the email
@@ -119,7 +123,7 @@ pub async fn login(
     // Finally, check the passwords
     if let Some(user) = user {
         user.check_password(payload.password)
-            .map_err(|_| StatusCode::BAD_REQUEST)?;
+            .map_err(|_| StatusCode::BAD_REQUEST)?;and return it
         let token =
             encode_jwt(&user.id.to_string()).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
         Ok(get_auth_response(&token))

--- a/packages/db/Cargo.toml
+++ b/packages/db/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-argon2 = "0.5"
+argon2 = { version = "0.5", features = ["password-hash"] }
 sqlx = { version = "0.7", features = ["runtime-tokio", "postgres", "chrono"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/packages/db/src/users.rs
+++ b/packages/db/src/users.rs
@@ -82,7 +82,7 @@ impl User {
     }
 }
 
-/// Hash a password using Argon2
+/// Hash a string using Argon2
 pub fn hash_string(password: &str) -> Result<String, argon2::password_hash::Error> {
     let salt = SaltString::generate(&mut OsRng);
     let argon2 = Argon2::default();

--- a/packages/db/src/users.rs
+++ b/packages/db/src/users.rs
@@ -1,30 +1,89 @@
 use argon2::{
     password_hash::{rand_core::OsRng, PasswordHasher, SaltString},
-    Argon2,
+    Argon2, PasswordVerifier,
 };
 use sqlx::{types::Uuid, PgPool};
 
-// Insert a new user into the database
-pub async fn insert_user(
-    pool: &PgPool,
-    email: &str,
-    username: &str,
-    password: &str,
-) -> Result<String, sqlx::Error> {
-    let user_id = Uuid::new_v4();
-    sqlx::query("INSERT INTO users (id, email, username, password_hash) VALUES ($1, $2, $3, $4)")
-        .bind(user_id)
-        .bind(email)
-        .bind(username)
-        .bind(password)
+#[derive(sqlx::FromRow)]
+/// A database representation of a user
+pub struct User {
+    pub id: Uuid,
+    pub email: String,
+    pub username: String,
+    pub password_hash: String,
+}
+
+pub enum UserError {
+    FailedToHashPassword,
+    BadPassword,
+}
+
+impl User {
+    /// Creates a new user from the given parameters
+    // NOTE: This does not hash the password by default
+    pub fn new(email: String, username: String, password_hash: String) -> Self {
+        let id = Uuid::new_v4();
+        User {
+            id,
+            email,
+            username,
+            password_hash,
+        }
+    }
+    /// Gets a user from the databased based on Username
+    pub async fn from_username(username: String, pool: &PgPool) -> Result<Self, sqlx::Error> {
+        sqlx::query_as::<_, User>("SELECT * FROM users WHERE username = $1")
+            .bind(username)
+            .fetch_one(pool)
+            .await
+    }
+    /// Gets a user from the database based on ID
+    pub async fn from_id(id: Uuid, pool: &PgPool) -> Result<Self, sqlx::Error> {
+        sqlx::query_as::<_, User>("SELECT * FROM users WHERE id = $1")
+            .bind(id)
+            .fetch_one(pool)
+            .await
+    }
+    /// Gets a user from the databased based on Email
+    pub async fn from_email(email: String, pool: &PgPool) -> Result<Self, sqlx::Error> {
+        sqlx::query_as::<_, User>("SELECT * FROM users WHERE email = $1")
+            .bind(email)
+            .fetch_one(pool)
+            .await
+    }
+    /// Checks that the raw password matches the expected-to-be-hashed password
+    pub fn check_password(&self, raw_password: String) -> Result<(), UserError> {
+        let dashed_password = argon2::password_hash::PasswordHash::new(&self.password_hash)
+            .map_err(|_| UserError::FailedToHashPassword)?;
+        argon2::Argon2::default()
+            .verify_password(raw_password.as_bytes(), &dashed_password)
+            .map_err(|_| UserError::BadPassword)
+    }
+    /// Hashes the password for the user
+    pub fn hash_password(&mut self) -> Result<&mut Self, UserError> {
+        let hashed_password =
+            hash_string(&self.password_hash).map_err(|_| UserError::FailedToHashPassword)?;
+        self.password_hash = hashed_password;
+        Ok(self)
+    }
+    /// Inserts the user into the database
+    pub async fn insert(&self, pool: &PgPool) -> Result<&Self, sqlx::Error> {
+        sqlx::query(
+            "INSERT INTO users (id, email, username, password_hash) VALUES ($1, $2, $3, $4)",
+        )
+        .bind(&self.id)
+        .bind(&self.email)
+        .bind(&self.username)
+        .bind(&self.password_hash)
         .execute(pool)
         .await?;
 
-    Ok(user_id.to_string())
+        Ok(self)
+    }
 }
 
-// Hash a password using Argon2
-pub fn hash_password(password: &str) -> Result<String, argon2::password_hash::Error> {
+/// Hash a password using Argon2
+pub fn hash_string(password: &str) -> Result<String, argon2::password_hash::Error> {
     let salt = SaltString::generate(&mut OsRng);
     let argon2 = Argon2::default();
     let password_hash = argon2

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -2,6 +2,7 @@
 	"name": "web",
 	"version": "0.0.1",
 	"type": "module",
+	"license": "MIT",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",

--- a/packages/web/src/app.d.ts
+++ b/packages/web/src/app.d.ts
@@ -3,7 +3,9 @@
 declare global {
 	namespace App {
 		// interface Error {}
-		// interface Locals {}
+		interface Locals {
+			authenticated: boolean;
+		}
 		// interface PageData {}
 		// interface PageState {}
 		// interface Platform {}

--- a/packages/web/src/hooks.server.ts
+++ b/packages/web/src/hooks.server.ts
@@ -1,0 +1,10 @@
+import type { Handle } from '@sveltejs/kit';
+
+export const handle: Handle = async ({ event, resolve }) => {
+	// Get the JWT from cookies
+	const jwt = event.cookies.get('jwt');
+	// Set the user as authenticated in the locals object if JWT exists
+	event.locals.authenticated = !!jwt;
+
+	return await resolve(event);
+};

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -1,0 +1,86 @@
+import { isAuthenticated } from './stores/auth';
+import { goto } from '$app/navigation';
+import { env } from '$env/dynamic/private';
+
+interface AuthResponse {
+	ok: boolean;
+	error?: string;
+}
+
+export async function login(username: string, password: string): Promise<AuthResponse> {
+	try {
+		const response = await fetch(`${env.API_URL}/auth/login`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json'
+			},
+			body: JSON.stringify({ username, password })
+		});
+
+		if (response.ok) {
+			isAuthenticated.set(true);
+			return { ok: true };
+		}
+
+		return {
+			ok: false,
+			error: 'Invalid credentials'
+		};
+	} catch (error) {
+		console.error('Could not login', error);
+		return {
+			ok: false,
+			error: 'An error occurred during login'
+		};
+	}
+}
+
+export async function register(
+	username: string,
+	email: string,
+	password: string,
+	passwordConfirmation: string
+): Promise<AuthResponse> {
+	try {
+		const response = await fetch(`${env.API_URL}/auth/register`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json'
+			},
+			body: JSON.stringify({
+				username,
+				email,
+				password,
+				password_confirmation: passwordConfirmation
+			})
+		});
+
+		if (response.ok) {
+			isAuthenticated.set(true);
+			return { ok: true };
+		}
+
+		return {
+			ok: false,
+			error: 'Registration failed'
+		};
+	} catch (error) {
+		console.error('Could not register', error);
+		return {
+			ok: false,
+			error: 'An error occurred during registration'
+		};
+	}
+}
+
+export async function logout() {
+	try {
+		await fetch(`${env.API_URL}/auth/logout`, {
+			method: 'POST'
+		});
+		isAuthenticated.set(false);
+		goto('/login');
+	} catch (error) {
+		console.error('Logout failed:', error);
+	}
+}

--- a/packages/web/src/lib/stores/auth.ts
+++ b/packages/web/src/lib/stores/auth.ts
@@ -1,0 +1,3 @@
+import { writable } from 'svelte/store';
+
+export const isAuthenticated = writable<boolean>(false);

--- a/packages/web/src/routes/+layout.server.ts
+++ b/packages/web/src/routes/+layout.server.ts
@@ -1,0 +1,7 @@
+import type { LayoutServerLoad } from './$types';
+
+export const load: LayoutServerLoad = async ({ locals }) => {
+	return {
+		authenticated: locals.authenticated
+	};
+};

--- a/packages/web/src/routes/+layout.svelte
+++ b/packages/web/src/routes/+layout.svelte
@@ -1,12 +1,19 @@
 <script lang="ts">
 	import '../app.css';
+	import { isAuthenticated } from '$lib/stores/auth';
+	import type { LayoutData } from './$types';
+	import type { Snippet } from 'svelte';
+
+	let { data, children }: { data: LayoutData; children: Snippet } = $props();
 	import ThemeToggler from '$lib/components/ThemeToggler.svelte';
 	import Header from '$lib/components/Header.svelte';
-	let { children } = $props();
 </script>
 
 <Header />
 <main>
+	{#if isAuthenticated}
+		<pre>{JSON.stringify(data, null, 2)}</pre>
+	{/if}
 	<div class="fixed right-4 top-4 z-50">
 		<ThemeToggler />
 	</div>

--- a/packages/web/src/routes/login/+page.server.ts
+++ b/packages/web/src/routes/login/+page.server.ts
@@ -1,0 +1,47 @@
+import { fail, redirect } from '@sveltejs/kit';
+import type { Actions } from './$types';
+import { env } from '$env/dynamic/private';
+
+export const actions = {
+	default: async ({ request, cookies }) => {
+		const data = await request.formData();
+		const username = data.get('username');
+		const password = data.get('password');
+
+		// Basic validation
+		if (!username || !password) {
+			return fail(400, {
+				error: 'Username and password are required',
+				username: username?.toString()
+			});
+		}
+
+		const response = await fetch(`${env.API_URL}/auth/login`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json'
+			},
+			body: JSON.stringify({
+				username: username.toString(),
+				password: password.toString()
+			})
+		});
+
+		if (!response.ok) {
+			const errorData = await response.json();
+			return fail(response.status, {
+				error: errorData.message || 'Invalid credentials',
+				username: username.toString()
+			});
+		}
+		const { token } = await response.json();
+
+		cookies.set('jwt', token, {
+			path: '/',
+			expires: new Date(Date.now() + 1000 * 60 * 60 * 24), // 24 hours
+			sameSite: true
+		});
+
+		throw redirect(303, '/');
+	}
+} satisfies Actions;

--- a/packages/web/src/routes/login/+page.svelte
+++ b/packages/web/src/routes/login/+page.svelte
@@ -1,1 +1,73 @@
-login page
+<script lang="ts">
+	import Alert from '$lib/components/Alert.svelte';
+	import { enhance } from '$app/forms';
+	import type { ActionResult } from '@sveltejs/kit';
+
+	export let form: ActionResult;
+	let isLoading = false;
+</script>
+
+<form
+	method="POST"
+	use:enhance={() => {
+		isLoading = true;
+		return async ({ update }) => {
+			await update();
+			isLoading = false;
+		};
+	}}
+	class="mx-auto mt-8 max-w-sm rounded-lg bg-white p-6 shadow-md dark:bg-secondary-950 dark:shadow-xl"
+>
+	{#if form?.error}
+		<Alert type="error" message={form.error} />
+	{/if}
+
+	<label class="mb-4 block">
+		<span class="text-sm text-secondary-800 dark:text-secondary-100">Username</span>
+		<input
+			name="username"
+			type="text"
+			value={form?.username ?? ''}
+			class="mt-1 block w-full
+                   rounded-md border-secondary-200 bg-white
+                   text-base shadow-sm
+                   focus:border-accent-500 focus:ring focus:ring-accent-200 focus:ring-opacity-50
+                   dark:border-secondary-800 dark:bg-secondary-900 dark:text-secondary-100
+                   dark:focus:border-accent-400 dark:focus:ring-accent-900"
+		/>
+	</label>
+
+	<label class="mb-4 block">
+		<span class="text-sm text-secondary-800 dark:text-secondary-100">Password</span>
+		<input
+			name="password"
+			type="password"
+			class="mt-1 block w-full
+                   rounded-md border-secondary-200 bg-white
+                   text-base shadow-sm
+                   focus:border-accent-500 focus:ring focus:ring-accent-200 focus:ring-opacity-50
+                   dark:border-secondary-800 dark:bg-secondary-900 dark:text-secondary-100
+                   dark:focus:border-accent-400 dark:focus:ring-accent-900"
+		/>
+	</label>
+
+	<button
+		type="submit"
+		disabled={isLoading}
+		class="flex w-full items-center
+               justify-center gap-2 rounded-md
+               bg-accent-500
+               px-4 py-2 text-sm font-medium
+               text-white hover:bg-accent-600 focus:outline-none focus:ring-2
+               focus:ring-accent-400 focus:ring-offset-2 disabled:cursor-not-allowed
+               disabled:opacity-50 dark:bg-accent-600
+               dark:hover:bg-accent-500
+               dark:focus:ring-accent-300 dark:focus:ring-offset-secondary-950"
+	>
+		{#if isLoading}
+			<span>Logging in...</span>
+		{:else}
+			<span>Login</span>
+		{/if}
+	</button>
+</form>


### PR DESCRIPTION
Passes the JWT back to the client in the API (svelte) and the client (svelte) will attach that to a cookie on the backend for the user